### PR TITLE
Acceptance link issue when the same mail address has different text c…

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
@@ -190,7 +190,9 @@ class TeamInvitation extends ContentEntityBase implements TeamInvitationInterfac
    * {@inheritdoc}
    */
   public function getRecipient(): ?string {
-    return $this->get('recipient')->value;
+    $recipientEmail = $this->get('recipient')->value;;
+    $user = user_load_by_mail($recipientEmail);
+    return $user ? $user->getEmail() : $recipientEmail;
   }
 
   /**


### PR DESCRIPTION
When inviting a new member to my team, consider the following example: the user's email is **_hello_Word@example.com_**, but I entered **_Hello_word@example.com_**. When they click on the acceptance link, they can't join the team due to a **case-sensitive error**.

In my code, it first retrieves the user object using the `user_load_by_mail` function with the recipient's email. If the user object is found, it retrieves the original user's email; otherwise, it obtains the recipient's email.